### PR TITLE
Fix meson deprecated syntax for get_variable and extern.full_path()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -168,7 +168,7 @@ fs = import('fs')
 
 if get_option('man')
     scdoc_prog = find_program(
-        scdoc_dep.get_pkgconfig_variable('scdoc'),
+        scdoc_dep.get_variable(pkgconfig: 'scdoc'),
         native: true
     )
     sh = find_program('sh', native: true)
@@ -191,7 +191,7 @@ if get_option('man')
             capture: true,
             output: output,
             command: [
-                sh, '-c', '@0@ < @INPUT@'.format(scdoc_prog.path())
+                sh, '-c', '@0@ < @INPUT@'.format(scdoc_prog.full_path())
             ],
             install: true,
             install_dir: '@0@/man@1@'.format(mandir, section)


### PR DESCRIPTION
`get_pkgconfig_variable()` and `externprog.path()` were deprecated in Meson [0.56.0](https://github.com/mesonbuild/meson/tree/0.56.0), (2020). Just a little 2-line edit.

`get_variable(pkgconfig: 'name')` and `externprog_prog.full_path()` are the supported syntax.