### PR TITLE
SELinux: use labeldb for creating user-owned files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,12 @@ scdoc_dep = dependency(
     native: true
 )
 
+libselinux_dep = dependency(
+    'libselinux',
+    version: '>=2.1.9',
+    required: get_option('support_selinux')
+)
+
 have_dinit = get_option('dinit').enabled()
 have_runit = get_option('runit').enabled()
 
@@ -31,6 +37,7 @@ conf_data.set_quoted('CONF_PATH', join_paths(
     get_option('prefix'), get_option('sysconfdir'), 'turnstile'
 ))
 conf_data.set10('MANAGE_RUNDIR', get_option('manage_rundir'))
+conf_data.set10('HAVE_SELINUX', libselinux_dep.found())
 
 conf_data.set('HAVE_PAM_MISC', pam_misc_dep.found())
 
@@ -82,7 +89,7 @@ daemon = executable(
     'turnstiled', daemon_sources,
     include_directories: extra_inc,
     install: true,
-    dependencies: [rt_dep, pam_dep, pam_misc_dep],
+    dependencies: [rt_dep, pam_dep, pam_misc_dep, libselinux_dep],
     gnu_symbol_visibility: 'hidden'
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,6 +38,11 @@ option('manage_rundir',
     description: 'Whether to manage rundir by default'
 )
 
+option('support_selinux',
+    type: 'feature', value: 'auto',
+    description: 'Whether to support SELinux',
+)
+
 option('man',
     type: 'boolean', value: true,
     description: 'Whether to generate manpages'


### PR DESCRIPTION
For SELinux-enabled systems, user owned files depend on the runtime libselinux login database, which affects the file_contexts selabeldb for user-owned paths (such as XDG_RUNTIME_DIR). This means that policy developers can't create XDG_RUNTIME_DIR (and other user-owned directories) with the correct context simply by using a filetrans in policy, so use libselinux to create the directories with the correct context ourselves.