### PR TITLE
Fix typo in XDG_RUNTIME_DIR path.

### DIFF
--- a/src/turnstiled.8.scd
+++ b/src/turnstiled.8.scd
@@ -17,7 +17,7 @@ For configuration, see *turnstiled.conf*(5).
 
 Upon user login, it spawns an instance of the chosen service manager for the
 user, while upon last logout, it shuts down this instance (unless configured
-to longer).
+to linger).
 
 User logins and logouts are communicated via *pam\_turnstile*(8).
 

--- a/turnstiled.conf.5.scd.in
+++ b/turnstiled.conf.5.scd.in
@@ -63,7 +63,7 @@ accept more values.
 
 	Valid values are _yes_, _no_ and _maybe_.
 
-*rundir\_path* (string: _@RUN_PATH@/usr/%u_)
+*rundir\_path* (string: _@RUN_PATH@/user/%u_)
 	The value of _$XDG\_RUNTIME\_DIR_ that is exported into the user service
 	environment. Special values _%u_ (user ID), _%g_ (group ID) and _%%_
 	(the character '%') are allowed and substituted in the string. Set to


### PR DESCRIPTION
Correct /run/usr to /run/user.