### PR TITLE
Add Simple User Services (suss) backend

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -38,3 +38,19 @@ if have_runit
         install_mode: 'rwxr-xr-x'
     )
 endif
+
+# suss backend
+
+if have_suss
+    install_data(
+        'suss',
+        install_dir: join_paths(get_option('libexecdir'), 'turnstile'),
+        install_mode: 'rwxr-xr-x'
+    )
+
+    install_data(
+        'suss.conf',
+        install_dir: join_paths(get_option('sysconfdir'), 'turnstile/backend'),
+        install_mode: 'rw-r--r--'
+    )
+endif

--- a/backend/suss
+++ b/backend/suss
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# Turnstile User Services control script
+#
+# $1 = run, ready, stop
+#
+
+case "$1" in
+    run) # $2 = fifo, $3 = srvdir, $4 = confdir
+	CONF=$4/${0##*/}.conf
+	[ -r "$CONF" ] && . "$CONF"
+
+	# Termination trap: kill session group
+	terminate_services() {
+	    # Ignore the signal we are about to send and don't run twice.
+	    trap '' EXIT TERM
+	    pkill -TERM -u "${USER}" -s 0 # Our processes in the session group
+	    sleep 5
+	    for PID in $(pgrep -u "${USER}" -s 0 | grep -wv $$); do # Still running?
+		kill -KILL "$PID" # The Big Hammer
+	    done
+	    exit 0 # All exited: success
+	}
+	trap "terminate_services" EXIT HUP TERM
+
+	# Restrict perms to user
+	umask 066
+
+	# Run user session service starts
+	# 1. Find all scripts
+	for DIR in $(IFS=:; echo ${USER_SESSION_PATH:=${HOME}/.user_session.d}); do
+	    [ -d "$DIR" ] || continue
+	    for SERVICE in "$DIR"/* ; do
+		X="$(echo "${SERVICE##*/}" | tr -d -- '-_+.[:alnum:]')"
+		[ -z "$X" ] || continue
+		[ -d "$SERVICE" ] && continue
+		echo "$SERVICE"
+	    done
+	done |
+	    # 2. Filter on first unique filenames
+	    awk -F'/' '{OFS="\t"; print $NF,$0}'  | sort -us -k1,1 | cut -f2 |
+	    # 3. Run if executable
+	    while read -r SERVICE; do
+		[ -x "$SERVICE" ] || continue
+		nohup "$SERVICE" >/dev/null 2>&1 </dev/null
+	    done
+
+	# Notify turnstiled with manager pid that session services
+	# are started and then wait until signalled.
+	printf '%d' $$ > "$2"
+	waitpid $$
+	;;
+
+    ready) # $2 = manager pid
+	: # Yes, nothing to do here.
+	;;
+
+    stop) # $2 = manager pid
+	# HUP the manager waitpid subprocess.
+	pkill -HUP -P "$2" waitpid
+	;;
+
+    *)
+	exit 1
+	;;
+esac

--- a/backend/suss.8.scd
+++ b/backend/suss.8.scd
@@ -1,0 +1,120 @@
+suss(8) "Turnstile Backend" "Simple User Session Service Usage Guide"
+
+# NAME
+
+suss - Simple User Session Service; a simple turnstile backend.
+
+# SYNOPSIS
+
+Implements the _turnstiled(8)_ backend API:
+
+	*suss* *run* _fifo_ _srvdir_ _confdir_++
+*suss* *ready* _string_++
+*suss* *stop* _runpid_
+
+# DESCRIPTION
+
+*suss* is a _turnstiled(8)_ backend for starting user session services
+by executing scripts and binaries found in any _$USER_SESSION_PATH_
+directories (e.g. _$HOME/.user_session.d:/etc/user_session.d_). These
+are run when a user first logs in to a host, and then stopped when the
+user's last login ends.
+
+Longer running services should be run as asynchronous background
+processes whilst retaining the current session ID. The service startup
+scripts (or binaries) must return directly after carrying out fast
+setup actions and/or spawning background services
+
+Upon the user's final logout, *suss* ensures that all services with
+the same session ID are terminated by means of the successive signals
+TERM and KILL.
+
+If several executables with the same filename are found in
+_$USER_SESSION_PATH_, only the first is used. A user could employ this
+to override a service installed system-wide.
+
+## Restarting Services
+
+The *suss* backend also handles signals HUP and TERM itself by
+terminating all running services (of its session ID) before exiting.
+_turnstiled(8)_ will then restart the *suss* service manager anew for
+a new start of the user session services.
+
+Note that service control startup filenames consist entirely of ASCII
+uppercase and lowercase letters, digits, underscore, full-stop
+(period), hyphen (minus) or plus. Filenames with other characters are
+silently ignored, as are any sub directories (regardless of their
+names) and all non-executable files.
+
+One may therefore, for instance, disable a service by making it
+non-executable. If then *suss* is sent a HUP signal, it will terminate
+all currently running services, including the ones just disabled, and
+subsequently restart only those that are still enabled.
+
+# EXAMPLES
+
+The following are examples of session service startup scripts for
+running a long term service, "myservice".
+
+## Simple Non-Repeating Session Action
+
+This example illustrates a control script for a simple non-repeating
+"myservice" service.
+
+	#!/bin/sh++
+myaction &++
+true
+
+Note that if the "myservice service is indeed simple and known to
+terminate quickly in all circumstances, then it might not need a
+service control script at all, but could be installed either directly
+or with a symbolic link in the _$HOME/user_session.d/_ directory.
+
+## Simple, Uncontrolled Repetition
+
+This example illustrates a simple, uncontrolled repetition of a
+"myservice", which merely re-runs the service repeatedly, should it
+exit:
+
+	#!/bin/sh++
+while true ; do myservice ; done &++
+true
+
+## Daemon Based Repetition
+
+This example illustrates using _daemon(1)_ for a more controlled
+repetition of the "myservice" service, where the service is re-run
+repeatedly under _daemon(1)_ control, should it exit:
+
+	#!/bin/sh++
+daemon -f -r -- myservice &++
+true
+
+## Propagating Environment Variables
+
+If the user service script needs to set variables in the user's environment,
+add this fragment to _$HOME/.profile_:
+
+	\[ -r "$XDG_RUNTIME_DIR/profile" \] && . "$XDG_RUNTIME_DIR/profile
+
+and append the export to _$XDG_RUNTIME_DIR/profile_ in the user service script:
+
+	#!/bin/sh++
+SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/openssh_agent++
+ssh-agent -D -a $SSH_AUTH_SOCK &++
+echo "export SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $XDG_RUNTIME_DIR/profile
+
+# CONFIGURATION
+
+*suss* uses a configuration file named *suss.conf* in the
+_turnstiled(8)_ backend configuration directory. This file is a
+POSIX sh fragment that gets sourced into *suss* on demand.
+
+Currently the only configuration is for _$USER_SESSION_PATH_ which
+nominates the (colon separated) directories  for user session
+service start programs.
+
+# CONTRIBUTORS
+
+Mark Hindley <mark@hindley.org.uk>++
+Ralph Ronnquist <rrq@rrq.au>

--- a/backend/suss.conf
+++ b/backend/suss.conf
@@ -1,0 +1,12 @@
+# Configuration file for turnstile's Simple User Services Shell
+# backend. See suss(8).
+#
+# It follows the POSIX shell syntax (being sourced into a script).
+#
+# It is a low-level configuration file. In most cases, it should not
+# be modified by the user.
+
+# Colon separated list of directories containing user session service
+# start scripts or binaries.
+#
+USER_SESSION_PATH="$HOME/.user_session.d:/etc/user_session.d"

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ scdoc_dep = dependency(
 
 have_dinit = get_option('dinit').enabled()
 have_runit = get_option('runit').enabled()
+have_suss = get_option('suss').enabled()
 
 conf_data = configuration_data()
 conf_data.set_quoted('RUN_PATH', get_option('rundir'))
@@ -132,6 +133,8 @@ if default_backend == ''
         default_backend = 'dinit'
     elif have_runit
         default_backend = 'runit'
+    elif have_suss
+        default_backend = 'suss'
     else
         default_backend = 'none'
     endif
@@ -179,6 +182,10 @@ if get_option('man')
         'src/pam_turnstile.8.scd',
         cscd,
     ]
+
+    if have_suss
+        man_files += 'backend/suss.8.scd'
+    endif
 
     foreach fobj: man_files
         filename = fs.name(fobj)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,11 @@ option('runit',
     description: 'Whether to install runit-related backend and data'
 )
 
+option('suss',
+    type: 'feature', value: 'disabled',
+    description: 'Whether to install suss-related backend and data'
+)
+
 option('default_backend',
     type: 'string', value: '',
     description: 'Override the default backend'

--- a/src/turnstiled.8.scd
+++ b/src/turnstiled.8.scd
@@ -17,7 +17,7 @@ For configuration, see *turnstiled.conf*(5).
 
 Upon user login, it spawns an instance of the chosen service manager for the
 user, while upon last logout, it shuts down this instance (unless configured
-to longer).
+to linger).
 
 User logins and logouts are communicated via *pam\_turnstile*(8).
 

--- a/turnstiled.conf.5.scd.in
+++ b/turnstiled.conf.5.scd.in
@@ -63,7 +63,7 @@ accept more values.
 
 	Valid values are _yes_, _no_ and _maybe_.
 
-*rundir\_path* (string: _@RUN_PATH@/usr/%u_)
+*rundir\_path* (string: _@RUN_PATH@/user/%u_)
 	The value of _$XDG\_RUNTIME\_DIR_ that is exported into the user service
 	environment. Special values _%u_ (user ID), _%g_ (group ID) and _%%_
 	(the character '%') are allowed and substituted in the string. Set to


### PR DESCRIPTION
Please consider incorporating this new backend.

It has been written with users of systems where there is no persistent service manager running in mind. It employs only long-established tools to achieve adequate functionality.

It is my intention to package this with the rest of turnstile for Debian.

Thanks

Mark